### PR TITLE
fixed typo in model Renting and seeds

### DIFF
--- a/app/models/renting.rb
+++ b/app/models/renting.rb
@@ -1,5 +1,5 @@
 class Renting < ApplicationRecord
-  STATUS = %w[pending accepted declined]
+  STATUS = %w[Pending Accepted Declined]
 
   belongs_to :renter, class_name: 'User'
   belongs_to :vinyl

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -246,7 +246,7 @@ renting_1 = Renting.create!(
   vinyl: christophe_vinyl_1,
   start_date: Date.today,
   end_date: Date.today + 7,
-  status: "pending",
+  status: "Pending",
   total_price: total_price
 )
 
@@ -257,7 +257,7 @@ renting_2 = Renting.create!(
   vinyl: christophe_vinyl_2,
   start_date: Date.today,
   end_date: Date.today + 6,
-  status: "pending",
+  status: "Pending",
   total_price: total_price
 )
 
@@ -268,7 +268,7 @@ renting_3 = Renting.create!(
   vinyl: christophe_vinyl_5,
   start_date: Date.today,
   end_date: Date.today + 10,
-  status: "pending",
+  status: "Pending",
   total_price: total_price
 )
 
@@ -279,7 +279,7 @@ renting_4 = Renting.create!(
   vinyl: bastien_vinyl_1,
   start_date: Date.today,
   end_date: Date.today + 5,
-  status: "accepted",
+  status: "Accepted",
   total_price: total_price
 )
 
@@ -290,7 +290,7 @@ renting_5 = Renting.create!(
   vinyl: corentin_vinyl_1,
   start_date: Date.today,
   end_date: Date.today + 1,
-  status: "declined",
+  status: "Declined",
   total_price: total_price
 )
 


### PR DESCRIPTION
dans 'schema.rb' on a rentings :status default "Pending"

> donc j'ai corrigé la var STATUS avec des status en capitalize dans le model Renting (plus simple que de corriger le schema par une nouvelle migration je suppose ?)

> file 'seeds.rb' corrigé également