### PR TITLE
fixed navbar place holder + added link to index on landing page

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -37,7 +37,7 @@ body > .container {
 
 .search {
   margin-top: 50px;
-  padding: 10px;
+  padding: 10px 10px 0px 10px;
 }
 .search-form-control {
   position: relative;
@@ -62,6 +62,9 @@ body > .container {
   box-shadow: 0 2px 6px rgba(0,0,0,0.08);
 }
 
-.index {
-  height: 800px;
+.surprise {
+  margin: 0px auto;
+  display: flex;
+  width: 150px;
+  justify-content: center;
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -12,14 +12,10 @@
             <i class="fas fa-search"></i> Search
           </button>
         </div>
+        <%= link_to "Surprise me!", vinyls_path, class: "btn btn-primary surprise"%>
       <% end %>
     </div>
   </div>
+  <!-- Add index partial here -->
 
-  <div class="index">
-
-  </div>
-  <div class="navbar">
-
-  </div>
 </div>


### PR DESCRIPTION
Fixed : remove navbar from landing page, which was causing duplicate navbars appearing on wide screens
New : link (button) to vinyls index on landing page