### PR TITLE
set root colors (and navbar) in order to match vinyls show

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,8 +19,8 @@
   font-family: "Open Sans";
   --text-primary: #b6b6b6;
   --text-secondary: #ececec;
-  --bg-primary: #343490;
-  --bg-secondary: #1a4e1e;
+  --bg-primary: #343a40;
+  --bg-secondary: #1edd88;
   --transition-speed: 600ms;
 }
 


### PR DESCRIPTION
I've changed the   --bg-primary and   --bg-secondary colors to match the ones used by Christophe in the vinyl show. it make the navbar a bit more beautiful.